### PR TITLE
Add defines for expansion Laurion's Song

### DIFF
--- a/Constants.h
+++ b/Constants.h
@@ -663,6 +663,7 @@ enum EQExpansion
 	EQExpansionCOV                  = EXPANSION_LEVEL_COV,
 	EQExpansionTOL                  = EXPANSION_LEVEL_TOL,
 	EQExpansionNOS                  = EXPANSION_LEVEL_NOS,
+	EQExpansionLS                   = EXPANSION_LEVEL_LS,
 };
 
 #define EQ_EXPANSION(x)             (1 << (x - 1))

--- a/Constants.h
+++ b/Constants.h
@@ -698,6 +698,7 @@ enum EQExpansion
 #define EXPANSION_COV               EQ_EXPANSION(EXPANSION_LEVEL_COV)
 #define EXPANSION_TOL               EQ_EXPANSION(EXPANSION_LEVEL_TOL)
 #define EXPANSION_NOS               EQ_EXPANSION(EXPANSION_LEVEL_NOS)
+#define EXPANSION_LS                EQ_EXPANSION(EXPANSION_LEVEL_LS)
 
 // Enumeration defining expansion bit mask representing expansion flags. Often used to
 // determine expansion ownership or requirements.
@@ -733,6 +734,7 @@ enum EQExpansionOwned
 	EQExpansionCOVOwned             = EXPANSION_COV,
 	EQExpansionTOLOwned             = EXPANSION_TOL,
 	EQExpansionNOSOwned             = EXPANSION_NOS,
+	EQExpansionLSOwned              = EXPANSION_LS,
 
 	// Mask representing all expansions
 	EQExpansionHighestOwnedPlusOne_,

--- a/Expansions.h
+++ b/Expansions.h
@@ -46,5 +46,6 @@ namespace eqlib {
 #define EXPANSION_LEVEL_COV             27  // Claws of Veeshan
 #define EXPANSION_LEVEL_TOL             28  // Terror of Luclin
 #define EXPANSION_LEVEL_NOS             29  // Night of Shadows
+#define EXPANSION_LEVEL_LS              30  // Laurion's Song
 
 } // namespace eqlib


### PR DESCRIPTION
Allows use of the check prior to the expansion release as well as enables a quick transition from current expansion level to the new expansion level for test and live branches.