### PR TITLE
Remove ClientString from ItemClient for Mar 16 test

### DIFF
--- a/include/eqlib/game/Items.h
+++ b/include/eqlib/game/Items.h
@@ -1255,7 +1255,7 @@ public:
 	__declspec(property(get = get_Item2)) ItemDefinition* Item2;
 };
 
-constexpr size_t ItemClient_size = 0x140; // @sizeof(ItemClient) :: 2026-03-03 (test) @ 0x1401EB009
+constexpr size_t ItemClient_size = 0x130; // @sizeof(ItemClient) :: 2026-03-16 (test) @ 0x1401EB1B9
 
 class [[offsetcomments]] ItemClient : public ItemBase
 {
@@ -1269,9 +1269,8 @@ public:
 
 	EQLIB_OBJECT static ItemPtr Create() { return eqstd::make_shared<ItemClient>(); }
 
-/*0x128*/ ItemDefinitionPtr SharedItemDef;
-/*0x138*/ CXStr             ClientString;
-/*0x140*/
+/*0x120*/ ItemDefinitionPtr SharedItemDef;
+/*0x130*/
 };
 
 SIZE_CHECK(ItemClient, ItemClient_size);


### PR DESCRIPTION
## Summary
- Remove `ClientString` (CXStr) from ItemClient - field no longer exists in the Mar 16 test binary
- ItemClient_size: 0x140 -> 0x130

## Verification
- `CreateItemClient` (0x1402C0430) allocates 0x140 bytes = 0x10 shared_ptr control block + 0x130 ItemClient object
- Constructor initializes fields at 0x118, 0x120, 0x128 only - nothing at 0x130
- Live memory scan of item instances confirms 0x130+ contains adjacent object data, not ItemClient fields
- Build tested in game with inventory, looting, and item interaction working