### PR TITLE
Remove ClientString from ItemClient for Mar 16 test

### DIFF
--- a/include/eqlib/game/Items.h
+++ b/include/eqlib/game/Items.h
@@ -1270,8 +1270,7 @@ public:
 	EQLIB_OBJECT static ItemPtr Create() { return eqstd::make_shared<ItemClient>(); }
 
 /*0x120*/ ItemDefinitionPtr SharedItemDef;
-/*0x130*/ CXStr             ClientString;
-/*0x138*/
+/*0x130*/
 };
 
 SIZE_CHECK(ItemClient, ItemClient_size);


### PR DESCRIPTION
## Summary
- Remove `ClientString` (CXStr) from ItemClient - field no longer exists in the Mar 16 test binary
- ItemClient_size: 0x138 -> 0x130

## Verification
- `CreateItemClient` (0x1402C0430) allocates 0x140 bytes = 0x10 shared_ptr control block + 0x130 ItemClient object
- Constructor initializes fields at 0x118, 0x120, 0x128 only - nothing at 0x130
- Live memory scan of item instances confirms 0x130+ contains adjacent object data, not ItemClient fields
- Build tested in game with inventory, looting, and item interaction working

Also fixes the () rendering bug around character names that was caused by ClientString data bleeding into spawn visibility checks.